### PR TITLE
Use randombytes package

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const signalhubws = require('signalhubws')
 const webrtcSwarm = require('@geut/discovery-swarm-webrtc')
 const DSS = require('discovery-swarm-stream/client')
 const websocket = require('websocket-stream')
-const crypto = require('crypto')
+const randomBytes = require('randombytes')
 
 const EventEmitter = require('events')
 
@@ -23,7 +23,7 @@ module.exports = class DiscoverySwarmWeb extends EventEmitter {
     const signalhubURL = opts.signalhub || DEFAULT_SIGNALHUB
     const discoveryURL = opts.discovery || DEFAULT_DISCOVERY
 
-    const id = opts.id || crypto.randomBytes(32)
+    const id = opts.id || randomBytes(32)
     const stream = opts.stream
 
     this.id = id

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@geut/discovery-swarm-webrtc": "github:geut/discovery-swarm-webrtc#sub-signalhub",
     "dat-swarm-defaults": "^1.0.2",
     "discovery-swarm-stream": "^1.1.5",
+    "randombytes": "^2.1.0",
     "signalhubws": "^1.0.10",
     "websocket-stream": "^5.1.2",
     "yargs": "^13.2.2"


### PR DESCRIPTION
Currently a browserify build without tree shaking includes the full browserify-crypto package. That's not needed, as in the module only the randomBytes function is used. There's an extracted version of that in the randombytes package. This PR makes use of this, which brings down browserify package size from 747KB to 298KB.