### PR TITLE
Update to discovery-swarm-webrtc v2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A websocket gets created for signaling WebRTC peers, and another one gets create
 `opts` include:
   - `stream`: The only required field. Return a stream to handle an incoming connection
   - `id`: The ID you want to use to show up in the swarm
-  - `signalhub`: Either a URL for a [signalhubws](https://www.npmjs.com/package/signalhubws) server used for WebRTC signaling, or an object that has the same interface as [signalhub](https://www.npmjs.com/package/signalhub). Uses [signalhubws.mauve.moe](wss://signalhubws.mauve.moe) by default. Note that each signalhub server creates a new WebRTC swarm, so you probably shouldn't change this.
+  - `bootstrap`: An array of [signal server urls](https://github.com/geut/discovery-swarm-webrtc#server) used for WebRTC discovery. Uses [signal.mauve.moe](https://signal.mauve.moe) by default.
   - `discovery`: A `discovery-swarm-web` server URl to connect to. By default it uses [discoveryswarm.mauve.moe](wss://discoveryswarm.mauve.moe), please supply your own if you're deploying to production. All discovery servers reach out to the same P2P network.
 
 ### `swarm.join(key)`
@@ -42,7 +42,7 @@ Stops looking for peers for the given `key`.
 
 ### `swarm.close()`, `swarm.destroy()`
 
-Close the swarm: closes all connections to peers, to the discovery server, and to the signalhub.
+Close the swarm: closes all connections to peers, to the discovery server.
 
 ## CLI
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,9 @@
-const DiscoverySwarmWeb = require('../')
+var path = require('path')
+
+// This is a dirty hack for browserify to work. 😅
+if (!path.posix) path.posix = path
+
+const discoverySwarmWeb = require('../')
 var hyperdrive = require('hyperdrive')
 var RAM = require('random-access-memory')
 
@@ -11,7 +16,7 @@ const archive = hyperdrive(RAM, ARCHIVE_KEY, {
 archive.ready(loadSwarm)
 
 function loadSwarm () {
-  const swarm = new DiscoverySwarmWeb({
+  const swarm = discoverySwarmWeb({
     stream: replicate
   })
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Abstracts away discovery-swarm interaction with WebRTC and a websocket gateway.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build-example": "browserify example/index.js > example/bundle.js",
-    "prepublish": "standard"
+    "test": "echo \"Error: no test specified\"",
+    "posttest": "standard",
+    "build-example": "browserify example/index.js > example/bundle.js"
   },
   "bin": {
     "discovery-swarm-web": "bin.js"
@@ -29,13 +29,12 @@
   },
   "homepage": "https://github.com/RangerMauve/discovery-swarm-web#readme",
   "dependencies": {
-    "@geut/discovery-swarm-webrtc": "github:geut/discovery-swarm-webrtc#sub-signalhub",
+    "@geut/discovery-swarm-webrtc": "^2.2.4",
     "debug": "^4.1.1",
     "discovery-swarm-stream": "^2.1.1",
     "hyperdiscovery": "^9.0.2",
     "length-prefixed-message": "^3.0.3",
     "randombytes": "^2.1.0",
-    "signalhubws": "^1.0.10",
     "websocket-stream": "^5.1.2",
     "yargs": "^13.2.2"
   },


### PR DESCRIPTION
This PR updates the discovery-swarm-webrtc to ^2.0.0.

related https://github.com/RangerMauve/discovery-swarm-web/issues/7

@RangerMauve Since we stop using signalhub you should create a new default public signal server. For testing purpose I left the public signal of Geut. I suggest in the readme something like: https://signal.mauve.moe

Any feedback or help is welcome :) as always